### PR TITLE
add global variables to member_import closes #277

### DIFF
--- a/crm/modules/member/command.inc.php
+++ b/crm/modules/member/command.inc.php
@@ -364,6 +364,8 @@ function command_member_membership_delete () {
  */
 function command_member_import () {
     global $config_org_name;
+    global $config_email_to;
+    global $config_email_from;
     
     // Verify permissions
     if (!user_access('member_add')) {


### PR DESCRIPTION
add global variables to member_import closes #277

new member emails were not being sent when members are imported from
CSV, this is why!
