### PR TITLE
remove "cash" string as method in billing #262, fix negative currency display #261, & split amount column

### DIFF
--- a/crm/modules/billing/billing.inc.php
+++ b/crm/modules/billing/billing.inc.php
@@ -290,7 +290,7 @@ function billing_bill_membership ($membership, $until, $after = '') {
             , 'code' => $prorated['code']
             , 'value' => $prorated['value']
             , 'credit_cid' => $membership['cid']
-            , 'method' => 'cash'
+            , 'method' => ''
         );
         payment_save($payment);
         // Advance to beginning of first full period
@@ -305,7 +305,7 @@ function billing_bill_membership ($membership, $until, $after = '') {
             , 'code' => $price['code']
             , 'value' => $price['value']
             , 'credit_cid' => $membership['cid']
-            , 'method' => 'cash'
+            , 'method' => ''
         );
         payment_save($payment);
         // Advance to next billing period

--- a/crm/modules/payment/payment.inc.php
+++ b/crm/modules/payment/payment.inc.php
@@ -649,7 +649,8 @@ function payment_table ($opts) {
         $table['columns'][] = array("title"=>'description');
         $table['columns'][] = array("title"=>'credit');
         $table['columns'][] = array("title"=>'debit');
-        $table['columns'][] = array("title"=>'amount');
+        $table['columns'][] = array("title"=>'amount charged');
+        $table['columns'][] = array("title"=>'amount paid');
         $table['columns'][] = array("title"=>'method');
         $table['columns'][] = array("title"=>'confirmation');
         $table['columns'][] = array("title"=>'notes');
@@ -676,7 +677,16 @@ function payment_table ($opts) {
             } else {
                 $row[] = '';
             }
-            $row[] = payment_format_currency($payment, true);
+            if ($payment['value']<=0) {
+                $row[] = payment_format_currency($payment, true);
+            } else {
+                $row[] = '';
+            }
+            if ($payment['value']>=0) {
+                $row[] = payment_format_currency($payment, true);
+            } else {
+                $row[] = '';
+            }
             $row[] = $payment['method'];
             $row[] = $payment['confirmation'];
             $row[] = $payment['notes'];

--- a/crm/modules/payment/payment.inc.php
+++ b/crm/modules/payment/payment.inc.php
@@ -201,7 +201,7 @@ function payment_format_currency ($value, $symbol = true) {
             }
             $result .= $dollars . '.' . $cents;
             if ($sign < 0) {
-                $result = '(' . $result . ')';
+                $result = '-' . $result;
             }
             break;
         case 'GBP':
@@ -217,7 +217,7 @@ function payment_format_currency ($value, $symbol = true) {
             }
             $result .= $pounds . '.' . $pence;
             if ($sign < 0) {
-                $result = '(' . $result . ')';
+                $result = '-' . $result;
             }
             break;
         case 'EUR':
@@ -233,7 +233,7 @@ function payment_format_currency ($value, $symbol = true) {
             }
             $result .= $euros . '.' . $cents;
             if ($sign < 0) {
-                $result = '(' . $result . ')';
+                $result = '-' . $result;
             }
             break;
         default:


### PR DESCRIPTION
* remove "cash" string as method in billing as mentioned by @elplatt in #262 

* changed negative currency display to be - instead of ( ) as suggested by @NateLapT & @myself248 in #261