### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/crm/include/sys/form.inc.php
+++ b/crm/include/sys/form.inc.php
@@ -265,7 +265,7 @@ function theme_form_text ($field) {
     if (!empty($field['suggestion'])) {
         array_push($classes, 'autocomplete');
     }
-    if (!empty($field['value']) && array_key_exists('defaultClear', $field) && $field['defaultClear'] == True)
+    if (!empty($field['value']) && array_key_exists('defaultClear', $field) && $field['defaultClear'] == true)
     {
         array_push($classes, 'defaultClear');
     }
@@ -285,7 +285,7 @@ function theme_form_text ($field) {
         if (!empty($field['value'])) {
             $output .= ' value="' . $field['value'] . '"';
             
-            if (array_key_exists('defaultClear', $field) && $field['defaultClear'] == True) {
+            if (array_key_exists('defaultClear', $field) && $field['defaultClear'] == true) {
                 $output .= ' title="' . $field['value'] . '"';
             }
         }

--- a/crm/include/sys/page.inc.php
+++ b/crm/include/sys/page.inc.php
@@ -90,7 +90,7 @@ function page_set_title (&$page_data, $title) {
  * @param $content The themed html content to add.
  * @param $tab_name The name of the tab.
  */
-function page_add_content_top (&$page_data, $content, $tab_name = NULL) {
+function page_add_content_top (&$page_data, $content, $tab_name = null) {
     if (!isset($tab_name)) {
         $tab_name = '#main';
     }
@@ -106,7 +106,7 @@ function page_add_content_top (&$page_data, $content, $tab_name = NULL) {
  * @param $content The themed html content to add.
  * @param $tab_name The name of the tab.
  */
-function page_add_content_bottom (&$page_data, $content, $tab_name = NULL) {
+function page_add_content_bottom (&$page_data, $content, $tab_name = null) {
     if (!isset($tab_name)) {
         $tab_name = '#main';
     }

--- a/crm/include/sys/table.inc.php
+++ b/crm/include/sys/table.inc.php
@@ -48,7 +48,7 @@ function crm_get_table ($table_id, $opts = array()) {
  * @param $opts Options to pass to the data function.
  * @return The themed html for a table.
 */
-function theme_table ($table_id, $opts = NULL) {
+function theme_table ($table_id, $opts = null) {
     
     // Check if $table_name is a string
     if (is_string($table_id)) {
@@ -162,7 +162,7 @@ function theme_table ($table_id, $opts = NULL) {
  * @param $opts Options to pass to the data function.
  * @return The CSV for a table.
 */
-function theme_table_csv ($table_name, $opts = NULL) {
+function theme_table_csv ($table_name, $opts = null) {
     
     // Check if $table_name is a string
     if (is_string($table_name)) {
@@ -218,7 +218,7 @@ function table_escape_csv ($cell) {
  * @param $opts Options to pass to the data function.
  * @return The themed html for a vertical table
 */
-function theme_table_vertical ($table_name, $opts = NULL) {
+function theme_table_vertical ($table_name, $opts = null) {
     
     // Check if $table_name is a string
     if (is_string($table_name)) {

--- a/crm/modules/contact/contact.inc.php
+++ b/crm/modules/contact/contact.inc.php
@@ -265,7 +265,7 @@ function contact_name_autocomplete ($fragment) {
 function contact_table ($opts = array()) {
     // Ensure user is allowed to view contacts
     if (!user_access('contact_view')) {
-        return NULL;
+        return null;
     }
     // Create table structure
     $table = array();

--- a/crm/modules/email_list/email_list.inc.php
+++ b/crm/modules/email_list/email_list.inc.php
@@ -659,7 +659,7 @@ function email_list_unsubscribe_form ($subscription) {
     // Ensure user is allowed to unsubscribe
     if (!user_access('email_list_unsubscribe')) {
         error_register('User does not have permission: email_list_unsubscribe');
-        return NULL;
+        return null;
     }
     
     // Get subscription data    
@@ -743,7 +743,7 @@ function email_list_create_form () {
 function email_list_edit_form ($lid) {
     if (!user_access('email_list_edit')) {
         error_register('User does not have permission: email_list_edit');
-        return NULL;
+        return null;
     }
     
     // Get email list data
@@ -798,7 +798,7 @@ function email_list_delete_form ($lid) {
     // Ensure user is allowed to delete keys
     if (!user_access('email_list_delete')) {
         error_register('User does not have permission: email_list_delete');
-        return NULL;
+        return null;
     }
     
     // Get email list data

--- a/crm/modules/key/key.inc.php
+++ b/crm/modules/key/key.inc.php
@@ -395,7 +395,7 @@ function key_add_form ($cid) {
     // Ensure user is allowed to edit keys
     if (!user_access('key_edit')) {
         error_register('User does not have permission: key_edit');
-        return NULL;
+        return null;
     }
     
     // Create form structure
@@ -455,7 +455,7 @@ function key_edit_form ($kid) {
     // Ensure user is allowed to edit keys
     if (!user_access('key_edit')) {
         error_register('User does not have permission: key_edit');
-        return NULL;
+        return null;
     }
     // Get key data
     $data = crm_get_data('key', array('kid'=>$kid));
@@ -533,7 +533,7 @@ function key_delete_form ($kid) {
     // Ensure user is allowed to delete keys
     if (!user_access('key_delete')) {
         error_register('User does not have permission: key_delete');
-        return NULL;
+        return null;
     }
     
     // Get key data

--- a/crm/modules/member/data.inc.php
+++ b/crm/modules/member/data.inc.php
@@ -352,7 +352,7 @@ function member_plan_data ($opts = array()) {
  * @param $opts Options to be passed to member_plan_data().
  * @return The associative array of membership plan descriptions.
  */
-function member_plan_options ($opts = NULL) {
+function member_plan_options ($opts = null) {
     
     // Get plan data
     $plans = member_plan_data($opts);

--- a/crm/modules/member/form.inc.php
+++ b/crm/modules/member/form.inc.php
@@ -141,7 +141,7 @@ function member_plan_add_form () {
     
     // Ensure user is allowed to edit plans
     if (!user_access('member_plan_edit')) {
-        return NULL;
+        return null;
     }
     
     // Create form structure
@@ -197,14 +197,14 @@ function member_plan_edit_form ($pid) {
     
     // Ensure user is allowed to edit plans
     if (!user_access('member_plan_edit')) {
-        return NULL;
+        return null;
     }
     
     // Get plan data
     $plans = member_plan_data(array('pid'=>$pid));
     $plan = $plans[0];
     if (!$plan) {
-        return NULL;
+        return null;
     }
     
     // Create form structure
@@ -266,7 +266,7 @@ function member_plan_delete_form ($pid) {
     
     // Ensure user is allowed to edit plans
     if (!user_access('member_plan_edit')) {
-        return NULL;
+        return null;
     }
     
     // Get plan description
@@ -313,7 +313,7 @@ function member_membership_add_form ($cid) {
     
     // Ensure user is allowed to edit memberships
     if (!user_access('member_membership_edit')) {
-        return NULL;
+        return null;
     }
     
     // Generate default start date, first of current month
@@ -372,7 +372,7 @@ function member_membership_edit_form ($sid) {
     
     // Ensure user is allowed to edit memberships
     if (!user_access('member_membership_edit')) {
-        return NULL;
+        return null;
     }
     
     // Get membership data
@@ -448,7 +448,7 @@ function member_membership_delete_form ($sid) {
     
     // Ensure user is allowed to edit memberships
     if (!user_access('member_membership_edit')) {
-        return NULL;
+        return null;
     }
     
     // Get membership data

--- a/crm/modules/member/table.inc.php
+++ b/crm/modules/member/table.inc.php
@@ -26,11 +26,11 @@
  * @param $opts Options to pass to member_data().
  * @return The table structure.
 */
-function member_table ($opts = NULL) {
+function member_table ($opts = null) {
     
     // Ensure user is allowed to view members
     if (!user_access('member_view')) {
-        return NULL;
+        return null;
     }
     
     // Determine settings
@@ -152,7 +152,7 @@ function member_voting_report_table () {
     
     // Ensure user is allowed to view members
     if (!user_access('member_view')) {
-        return NULL;
+        return null;
     }
     
     // Get member data
@@ -212,11 +212,11 @@ function member_voting_report_table () {
  * @param $opts Options to pass to member_plan_data().
  * @return The table structure.
 */
-function member_plan_table ($opts = NULL) {
+function member_plan_table ($opts = null) {
     
     // Ensure user is allowed to view membership plans
     if (!user_access('member_plan_edit')) {
-        return NULL;
+        return null;
     }
     
     // Get membership plan data
@@ -285,10 +285,10 @@ function member_plan_table ($opts = NULL) {
  * @param $opts Options to pass to member_membership_data().
  * @return The table structure.
 */
-function member_membership_table ($opts = NULL) {
+function member_membership_table ($opts = null) {
     // Ensure user is allowed to view members
     if (!user_access('member_membership_view')) {
-        return NULL;
+        return null;
     }
     // Get member data
     $memberships = member_membership_data($opts);
@@ -383,11 +383,11 @@ function member_contact_table ($opts) {
  * @param $opts Options to pass to member_data().
  * @return The table structure.
 */
-function member_info_table ($opts = NULL) {
+function member_info_table ($opts = null) {
     
     // Ensure user is allowed to view members
     if (!user_access('member_view')) {
-        return NULL;
+        return null;
     }
     
     // Determine settings

--- a/crm/modules/member/theme.inc.php
+++ b/crm/modules/member/theme.inc.php
@@ -26,7 +26,7 @@
  * @param $opts Options to pass to member_data().
  * @return The themed html string.
 */
-function theme_member_table ($opts = NULL) {
+function theme_member_table ($opts = null) {
     return theme('table', crm_get_table('member', $opts));
 }
 
@@ -36,7 +36,7 @@ function theme_member_table ($opts = NULL) {
  * @param $opts The options to pass to member_contact_data().
  * @return The themed html string.
 */
-function theme_member_contact_table ($opts = NULL) {
+function theme_member_contact_table ($opts = null) {
     return theme('table_vertical', crm_get_table('member_contact', $opts));
 }
 
@@ -204,7 +204,7 @@ EOF;
  * @param $opts The options to pass to member_membership_data().
  * @return The themed html string.
  */
-function theme_member_membership_table ($opts = NULL) {
+function theme_member_membership_table ($opts = null) {
     return theme('table', crm_get_table('member_membership', $opts));
 }
 
@@ -234,7 +234,7 @@ function theme_member_membership_edit_form ($sid) {
  * @param $opts The options to pass to member_plan_data().
  * @return The themed html string.
  */
-function theme_member_plan_table ($opts = NULL) {
+function theme_member_plan_table ($opts = null) {
     return theme('table', crm_get_table('member_plan', $opts));
 }
 
@@ -263,7 +263,7 @@ function theme_member_plan_edit_form ($pid) {
  * @param $opts The options to pass to member_data().
  * @return The themed html string.
  */
-function theme_member_info_table ($opts = NULL) {
+function theme_member_info_table ($opts = null) {
     return theme('table_vertical', crm_get_table('member_info', $opts));
 }
 

--- a/crm/modules/mentor/mentor.inc.php
+++ b/crm/modules/mentor/mentor.inc.php
@@ -374,7 +374,7 @@ function mentor_add_form ($cid) {
     
     // Ensure user is allowed to edit mentors
     if (!user_access('mentor_edit')) {
-        return NULL;
+        return null;
     }
     
     // Create form structure
@@ -420,7 +420,7 @@ function mentor_edit_form ($cid) {
     
     // Ensure user is allowed to edit mentor
     if (!user_access('mentor_edit')) {
-        return NULL;
+        return null;
     }
         
     // Get corresponding contact data
@@ -496,7 +496,7 @@ function mentor_delete_form ($cid) {
     
     // Ensure user is allowed to delete mentors
     if (!user_access('mentor_delete')) {
-        return NULL;
+        return null;
     }
     
     // Get corresponding contact data

--- a/crm/modules/payment/payment.inc.php
+++ b/crm/modules/payment/payment.inc.php
@@ -391,10 +391,10 @@ function payment_save ($payment) {
     // Verify permissions and validate input
     if (!user_access('payment_edit')) {
         error_register('Permission denied: payment_edit');
-        return NULL;
+        return null;
     }
     if (empty($payment)) {
-        return NULL;
+        return null;
     }
     // Sanitize input
     $esc_pmtid = mysqli_real_escape_string($db_connect, $payment['pmtid']);
@@ -574,7 +574,7 @@ function payment_accounts ($opts = array()) {
  * @return An array of cids for matching contacts, or NULL if all match.
  */
 function payment_contact_filter ($filter) {
-    $cids = NULL;
+    $cids = null;
     foreach ($filter as $key => $value) {
         $new_cids = array();
         switch ($key) {
@@ -589,7 +589,7 @@ function payment_contact_filter ($filter) {
                 }
                 break;
             default:
-                $new_cids = NULL;
+                $new_cids = null;
         }
         if (is_null($cids)) {
             $cids = $new_cids;
@@ -839,7 +839,7 @@ function payment_add_form () {
     
     // Ensure user is allowed to edit payments
     if (!user_access('payment_edit')) {
-        return NULL;
+        return null;
     }
     
     // Create form structure
@@ -920,12 +920,12 @@ function payment_edit_form ($pmtid) {
     // Ensure user is allowed to edit payments
     if (!user_access('payment_edit')) {
         error_register('User does not have permission: payment_edit');
-        return NULL;
+        return null;
     }
     // Get payment data
     $data = crm_get_data('payment', array('pmtid'=>$pmtid));
     if (count($data) < 1) {
-        return NULL;
+        return null;
     }
     $payment = $data[0];
     $credit = '';
@@ -1027,7 +1027,7 @@ function payment_edit_form ($pmtid) {
 function payment_delete_form ($pmtid) {
     // Ensure user is allowed to delete keys
     if (!user_access('payment_delete')) {
-        return NULL;
+        return null;
     }
     // Get data
     $data = crm_get_data('payment', array('pmtid'=>$pmtid));

--- a/crm/modules/plan_meta/plan_meta.inc.php
+++ b/crm/modules/plan_meta/plan_meta.inc.php
@@ -534,7 +534,7 @@ function plan_meta_add_form ($pid) {
     
     // Ensure user is allowed to edit metas
     if (!user_access('plan_meta_edit')) {
-        return NULL;
+        return null;
     }
     
     // Create form structure
@@ -591,7 +591,7 @@ function plan_meta_edit_form ($pmid) {
     
     // Ensure user is allowed to edit meta
     if (!user_access('plan_meta_edit')) {
-        return NULL;
+        return null;
     }
     
     // Get meta data
@@ -667,7 +667,7 @@ function plan_meta_delete_form ($pmid) {
     
     // Ensure user is allowed to delete metas
     if (!user_access('plan_meta_delete')) {
-        return NULL;
+        return null;
     }
     
     // Get meta data

--- a/crm/modules/user/user.inc.php
+++ b/crm/modules/user/user.inc.php
@@ -312,7 +312,7 @@ function user_data_alter ($type, $data = array(), $opts = array()) {
  * @param $opts An associative array of options.
  * @return An array with each element representing a role.
 */ 
-function user_role_data ($opts = NULL) {
+function user_role_data ($opts = null) {
     global $db_connect;
     // Construct map from role ids to arrays of permissions granted
     $permissionMap = array();
@@ -508,7 +508,7 @@ function user_check_password($password, $user) {
  * @param $cid The cid of the user being queried, defaults to current user.
  * @return The username for the specified user.
 */
-function user_username($cid = NULL) {
+function user_username($cid = null) {
     $opts = array();
     if ($cid) {
         $opts['cid'] = $cid;
@@ -707,7 +707,7 @@ function command_login () {
     
     //Check to see if there was an @ sign in the 'username'. This will signify that the user
     //probably entered their email, and not their username.
-    if (strpos($_POST['username'], "@") === False){
+    if (strpos($_POST['username'], "@") === false){
         //there is not an "@" in the 'username', so we will assume the user entered their username
         $user_opts = array(
             'filter' => array(

--- a/crm/modules/user_meta/user_meta.inc.php
+++ b/crm/modules/user_meta/user_meta.inc.php
@@ -600,7 +600,7 @@ function user_meta_add_form ($cid) {
     
     // Ensure user is allowed to edit metas
     if (!user_access('user_meta_edit')) {
-        return NULL;
+        return null;
     }
     
     // Create form structure
@@ -622,7 +622,7 @@ function user_meta_add_form ($cid) {
                         'name' => 'tagstr',
                         'value' => '[please enter a meaningful metatag here]',
                         'suggestion' => 'meta_tag',
-                        'defaultClear' => True
+                        'defaultClear' => true
                     ),
                     array(
                         'type' => 'text',
@@ -659,7 +659,7 @@ function user_meta_edit_form ($umid) {
     
     // Ensure user is allowed to edit meta
     if (!user_access('user_meta_edit')) {
-        return NULL;
+        return null;
     }
     
     // Get meta data
@@ -735,7 +735,7 @@ function user_meta_delete_form ($umid) {
     
     // Ensure user is allowed to delete metas
     if (!user_access('user_meta_delete')) {
-        return NULL;
+        return null;
     }
     
     // Get meta data


### PR DESCRIPTION
Changed keyword constant comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2

@chris18890 Reopened [428](https://github.com/elplatt/seltzer/pull/428) to dev branch as requested.