### PR TITLE
add https url

### DIFF
--- a/crm/config.sample.inc.php
+++ b/crm/config.sample.inc.php
@@ -63,6 +63,9 @@ $config_base_path = '/crm/';
 $config_github_username = 'elplatt';
 $config_github_repo = 'seltzer';
 
+// sets the protocol for URLs in outgoing emails, can be set to http or https
+$config_protocol_security = 'https';
+
 // The name of the theme you want to use
 // (currently there is only one, "inspire".)
 $config_theme = "inspire";

--- a/crm/include/sys/util.inc.php
+++ b/crm/include/sys/util.inc.php
@@ -121,3 +121,11 @@ function github_repo () {
     global $config_github_repo;
     return $config_github_repo;
 }
+
+/**
+ * @return The URL protocol configured in config.inc.php for use in outgoing emails.
+ */
+function protocol_security () {
+    global $config_protocol_security;
+    return $config_protocol_security;
+}

--- a/crm/modules/user/user.inc.php
+++ b/crm/modules/user/user.inc.php
@@ -664,6 +664,7 @@ function user_reset_password_url ($username) {
     global $db_connect;
     global $config_host;
     global $config_base_path;
+    global $config_protocol_security;
     // Get user info
     $esc_username = mysqli_real_escape_string($db_connect, $username);
     $sql = "
@@ -692,7 +693,7 @@ function user_reset_password_url ($username) {
     ";
     $res = mysqli_query($db_connect, $sql);
     // Generate reset url
-    $url = 'http://' . $config_host . crm_url("reset-confirm&v=" . $code);
+    $url = $config_protocol_security . '://' . $config_host . crm_url("reset-confirm&v=" . $code);
     return $url;
 }
 

--- a/crm/themes/inspire/email-welcome.tpl.php
+++ b/crm/themes/inspire/email-welcome.tpl.php
@@ -10,6 +10,7 @@
     global $config_org_website;
     global $config_email_from;
     global $config_protocol_security;
+    print '<html>';
     print 'Welcome to ' . "$config_org_name" . '!';
     print '<br /><br />';
     print 'You are receiving this email because you have recently been entered into the ' . "$config_org_name" . ' membership management system, ' . "$config_site_title" . '.';
@@ -25,5 +26,6 @@
     }
     print '<br /><br />';
     print 'If you have any additional questions, please contact: <a href="mailto:' . "$config_email_from" . '">' . "$config_email_from" . '</a> or visit the website at <a href="' . "$config_protocol_security" . '://' . "$config_org_website" . '">' . "$config_protocol_security" . '://' . "$config_org_website";
+    print '</html>';
     ?>
 </p>

--- a/crm/themes/inspire/email-welcome.tpl.php
+++ b/crm/themes/inspire/email-welcome.tpl.php
@@ -9,13 +9,14 @@
     global $config_org_name;
     global $config_org_website;
     global $config_email_from;
+    global $config_protocol_security;
     print 'Welcome to ' . "$config_org_name" . '!';
     print '<br /><br />';
     print 'You are receiving this email because you have recently been entered into the ' . "$config_org_name" . ' membership management system, ' . "$config_site_title" . '.';
     print '<br /><br />';
     print 'Your username is ' . "$username" . '. To confirm your email and set your password, visit <a href="' . "$confirm_url". '">' . "$confirm_url" . '</a>.';
     print '<br /><br />';
-    print 'You may manage your contact info at: <a href="http://' . "$hostname$base_path" . '">http://' . "$hostname$base_path" . '</a>';
+    print 'You may manage your contact info at: <a href="' . "$config_protocol_security" . '://' . "$hostname$base_path" . '">' . "$config_protocol_security" . '://' . "$hostname$base_path" . '</a>';
     print '<br /><br />';
     print 'Please ensure the information we have on file for you is complete and accurate.';
     print '<br /><br />';
@@ -23,6 +24,6 @@
         print 'Our address is ' . "$config_address1" . ", " . "$config_address2" . ", " . "$config_address3" . ", " . "$config_town_city" . ", " . "$config_zipcode";
     }
     print '<br /><br />';
-    print 'If you have any additional questions, please contact: <a href="mailto:' . "$config_email_from" . '">' . "$config_email_from" . '</a> or visit the website at <a href="' . "$config_org_website" . '">' . "$config_org_website";
+    print 'If you have any additional questions, please contact: <a href="mailto:' . "$config_email_from" . '">' . "$config_email_from" . '</a> or visit the website at <a href="' . "$config_protocol_security" . '://' . "$config_org_website" . '">' . "$config_protocol_security" . '://' . "$config_org_website";
     ?>
 </p>


### PR DESCRIPTION
have URLs in outgoing emails use HTTPS, but provide the option to configure for plain HTTP as well