### PR TITLE
refactor members

### DIFF
--- a/crm/include/crm.inc.php
+++ b/crm/include/crm.inc.php
@@ -24,7 +24,7 @@
 $crm_version = array(
     'major' => 0
     , 'minor' => 7
-    , 'patch' => 2
+    , 'patch' => 3
     , 'revision' => 'dev'
 );
 require_once($crm_root . '/config.inc.php');

--- a/crm/modules/member/command.inc.php
+++ b/crm/modules/member/command.inc.php
@@ -167,27 +167,19 @@ function command_member_edit () {
     global $db_connect;
     global $esc_post;
     $esc_cid = mysqli_real_escape_string($db_connect, $_POST['cid']);
-    $esc_emergencyName = mysqli_real_escape_string($db_connect, $_POST['emergencyName']);
-    $esc_emergencyPhone = mysqli_real_escape_string($db_connect, $_POST['emergencyPhone']);
-    $esc_emergencyRelation = mysqli_real_escape_string($db_connect, $_POST['emergencyRelation']);
-    $esc_address1 = mysqli_real_escape_string($db_connect, $_POST['address1']);
-    $esc_address2 = mysqli_real_escape_string($db_connect, $_POST['address2']);
-    $esc_address3 = mysqli_real_escape_string($db_connect, $_POST['address3']);
-    $esc_town_city = mysqli_real_escape_string($db_connect, $_POST['town_city']);
-    $esc_zipcode = mysqli_real_escape_string($db_connect, $_POST['zipcode']);
     $member_data = crm_get_data('member', array('cid'=>$esc_cid));
     $member = $member_data[0]['member'];
     // Add member fields
     $member = array(
         'cid'=> $esc_cid
-        , 'emergencyName' => $esc_emergencyName
-        , 'emergencyPhone' => $esc_emergencyPhone
-        , 'emergencyRelation' => $esc_emergencyRelation
-        , 'address1' => $esc_address1
-        , 'address2' => $esc_address2
-        , 'address3' => $esc_address3
-        , 'town_city' => $esc_town_city
-        , 'zipcode' => $esc_zipcode
+        , 'emergencyName' => $_POST['emergencyName']
+        , 'emergencyPhone' => $_POST['emergencyPhone']
+        , 'emergencyRelation' => $_POST['emergencyRelation']
+        , 'address1' => $_POST['address1']
+        , 'address2' => $_POST['address2']
+        , 'address3' => $_POST['address3']
+        , 'town_city' => $_POST['town_city']
+        , 'zipcode' => $_POST['zipcode']
     );
     // Save to database
     $member = member_save($member);

--- a/crm/modules/member/data.inc.php
+++ b/crm/modules/member/data.inc.php
@@ -217,14 +217,13 @@ function member_contact_api ($contact, $op) {
         return $contact;
     }
     $esc_cid = mysqli_real_escape_string($db_connect, $contact['cid']);
-    $esc_emergencyName = mysqli_real_escape_string($db_connect, $contact['member']['emergencyName']);
-    $esc_emergencyPhone = mysqli_real_escape_string($db_connect, $contact['member']['emergencyPhone']);
-    $esc_emergencyRelation = mysqli_real_escape_string($db_connect, $contact['member']['emergencyRelation']);
-    $esc_address1 = mysqli_real_escape_string($db_connect, $contact['member']['address1']);
-    $esc_address2 = mysqli_real_escape_string($db_connect, $contact['member']['address2']);
-    $esc_address3 = mysqli_real_escape_string($db_connect, $contact['member']['address3']);
-    $esc_town_city = mysqli_real_escape_string($db_connect, $contact['member']['town_city']);
-    $esc_zipcode = mysqli_real_escape_string($db_connect, $contact['member']['zipcode']);
+    $fields = array(
+        'emergencyName', 'emergencyPhone', 'emergencyRelation', 'address1', 'address2', 'address3', 'town_city', 'zipcode'
+    );
+    $escaped = array();
+    foreach ($fields as $field) {
+        $escaped[$field] = mysqli_real_escape_string($db_connect, $contact['member'][$field]);
+    }
     switch ($op) {
         case 'create':
             // Add member
@@ -233,7 +232,7 @@ function member_contact_api ($contact, $op) {
                 INSERT INTO `member`
                 (`cid`, `emergencyName`, `emergencyPhone`, `emergencyRelation`, `address1`, `address2`, `address3`, `town_city`, `zipcode`)
                 VALUES
-                ('$esc_cid', '$esc_emergencyName', '$esc_emergencyPhone', '$esc_emergencyRelation', '$esc_address1', '$esc_address2', '$esc_address3', '$esc_town_city', '$esc_zipcode')
+                ('$esc_cid', '$escaped[emergencyName]', '$escaped[emergencyPhone]', '$escaped[emergencyRelation]', '$escaped[address1]', '$escaped[address2]', '$escaped[address3]', '$escaped[town_city]', '$escaped[zipcode]')
             ";
             $res = mysqli_query($db_connect, $sql);
             if (!$res) crm_error(mysqli_error($res));


### PR DESCRIPTION
removs a duplication of the "mysqli_real_escape_string" function, duesn't need to happen in _command.php if its happening in _data.php; also chaning how it's done in data to use arrays than a bunch of strings, makes it slightly easier to add new values in future