### PR TITLE
Permission changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Seltzer CRM 0.7.5 - An open source CRM for hackerspaces  
+Seltzer CRM 0.7.6 - An open source CRM for hackerspaces  
 Copyright 2009-2021 Edward L. Platt <ed@elplatt.com>  
 Distributed under GPLv3 (see COPYING for more info)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Seltzer CRM 0.7.2 - An open source CRM for hackerspaces  
+Seltzer CRM 0.7.4 - An open source CRM for hackerspaces  
 Copyright 2009-2021 Edward L. Platt <ed@elplatt.com>  
 Distributed under GPLv3 (see COPYING for more info)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Seltzer CRM 0.7.4 - An open source CRM for hackerspaces  
+Seltzer CRM 0.7.5 - An open source CRM for hackerspaces  
 Copyright 2009-2021 Edward L. Platt <ed@elplatt.com>  
 Distributed under GPLv3 (see COPYING for more info)
 

--- a/crm/include/crm.inc.php
+++ b/crm/include/crm.inc.php
@@ -24,7 +24,7 @@
 $crm_version = array(
     'major' => 0
     , 'minor' => 7
-    , 'patch' => 4
+    , 'patch' => 5
     , 'revision' => 'dev'
 );
 require_once($crm_root . '/config.inc.php');

--- a/crm/include/crm.inc.php
+++ b/crm/include/crm.inc.php
@@ -24,7 +24,7 @@
 $crm_version = array(
     'major' => 0
     , 'minor' => 7
-    , 'patch' => 5
+    , 'patch' => 6
     , 'revision' => 'dev'
 );
 require_once($crm_root . '/config.inc.php');

--- a/crm/include/crm.inc.php
+++ b/crm/include/crm.inc.php
@@ -24,7 +24,7 @@
 $crm_version = array(
     'major' => 0
     , 'minor' => 7
-    , 'patch' => 3
+    , 'patch' => 4
     , 'revision' => 'dev'
 );
 require_once($crm_root . '/config.inc.php');

--- a/crm/include/page.inc.php
+++ b/crm/include/page.inc.php
@@ -48,23 +48,18 @@ function core_page_list () {
 }
 
 /**
- * Page hook.  Adds member module content to a page before it is rendered.
+ * Page hook. Adds member module content to a page before it is rendered.
  * @param &$page_data Reference to data about the page being rendered.
  * @param $page_name The name of the page being rendered.
  * @param $options The array of options passed to theme('page').
  */
 function core_page (&$page_data, $page_name, $options) {
-    
     $latestNews = '<p>Welcome to ' . title() . ' version ' . crm_version() . '!</p>';
-    
     // Modify this variable with valid HTML between the apostrophes to display update text to users on login
-    
     $latestNews = $latestNews . '
         <p><p>
     ';
-    
     switch ($page_name) {
-        
         case '<front>':
             page_add_content_top($page_data, $latestNews);
             break;

--- a/crm/include/sys/form.inc.php
+++ b/crm/include/sys/form.inc.php
@@ -90,7 +90,7 @@ function theme_form ($form) {
         if (!empty($form['action'])) {
             $output .= $form['action'] . '"';
         } else {
-            $output .= crm_url('').'"';
+            $output .= crm_url('') . '"';
         }
         if (array_key_exists('enctype', $form)) {
             $output .= ' enctype="' . $form['enctype'] . '"';
@@ -202,7 +202,9 @@ function theme_form_table ($field) {
  * @return The themed html string for a message form element.
  */
 function theme_form_message($field) {
-    if (!array_key_exists('class', $field)) { $field['class'] = ''; }
+    if (!array_key_exists('class', $field)) {
+        $field['class'] = '';
+    }
     $output = '<fieldset class="form-row ' . $field['class'] . '">';
     $output .= $field['value'];
     $output .= '</fieldset>';
@@ -215,7 +217,9 @@ function theme_form_message($field) {
  * @return The themed html for a read-only form field.
  */
 function theme_form_readonly ($field) {
-    if (!array_key_exists('class', $field)) { $field['class'] = ''; }
+    if (!array_key_exists('class', $field)) {
+        $field['class'] = '';
+    }
     $output = '<fieldset class="form-row ' . $field['class'] . '">';
     if (!empty($field['label'])) {
         $output .= '<label>' . $field['label'] . '</label>';
@@ -236,7 +240,9 @@ function theme_form_readonly ($field) {
  * @return The themed html for the text field.
  */
 function theme_form_text ($field) {
-    if (!array_key_exists('class', $field)) { $field['class'] = ''; }
+    if (!array_key_exists('class', $field)) {
+        $field['class'] = '';
+    }
     $classes = array();
     if (array_key_exists('class', $field) && !empty($field['class'])) {
         array_push($classes, $field['class']);
@@ -265,7 +271,6 @@ function theme_form_text ($field) {
     if (empty($field['autocomplete'])) {
         if (!empty($field['value'])) {
             $output .= ' value="' . $field['value'] . '"';
-            
             if (array_key_exists('defaultClear', $field) && $field['defaultClear'] == true) {
                 $output .= ' title="' . $field['value'] . '"';
             }
@@ -360,7 +365,9 @@ function theme_form_password ($field) {
  * @return The themed html for the field.
  */
 function theme_form_file ($field) {
-    if (!array_key_exists('class', $field)) { $field['class'] = ''; }
+    if (!array_key_exists('class', $field)) {
+        $field['class'] = '';
+    }
     $output = '<fieldset class="form-row ' . $field['class'] . '">';
     if (!empty($field['label'])) {
         $output .= '<label>' . $field['label'] . '</label>';

--- a/crm/include/sys/form.inc.php
+++ b/crm/include/sys/form.inc.php
@@ -247,10 +247,10 @@ function theme_form_text ($field) {
     if (array_key_exists('class', $field) && !empty($field['class'])) {
         array_push($classes, $field['class']);
     }
-    if (!empty($field['autocomplete'])) {
+    if (array_key_exists('autocomplete', $field) && !empty($field['autocomplete'])) {
         array_push($classes, 'autocomplete');
     }
-    if (!empty($field['suggestion'])) {
+    if (array_key_exists('suggestion', $field) && !empty($field['suggestion'])) {
         array_push($classes, 'autocomplete');
     }
     if (!empty($field['value']) && array_key_exists('defaultClear', $field) && $field['defaultClear'] == true) {

--- a/crm/include/sys/page.inc.php
+++ b/crm/include/sys/page.inc.php
@@ -116,7 +116,6 @@ function page_add_content_bottom (&$page_data, $content, $tab_name = null) {
 
 /**
  * Theme an entire page.
- *
  * @param $page_name The page name.
  * @param $options The options to pass to page().
  * @return The themed html for the page.

--- a/crm/include/sys/table.inc.php
+++ b/crm/include/sys/table.inc.php
@@ -142,7 +142,7 @@ function theme_table ($table_id, $opts = null) {
  * @param $table_name The name of the table or the table data.
  * @param $opts Options to pass to the data function.
  * @return The CSV for a table.
-*/
+ */
 function theme_table_csv ($table_name, $opts = null) {
     // Check if $table_name is a string
     if (is_string($table_name)) {

--- a/crm/modules/contact/contact.inc.php
+++ b/crm/modules/contact/contact.inc.php
@@ -585,7 +585,7 @@ function contact_page_list () {
 }
 
 /**
- * Page hook.  Adds contact module content to a page before it is rendered.
+ * Page hook. Adds contact module content to a page before it is rendered.
  * @param &$page_data Reference to data about the page being rendered.
  * @param $page_name The name of the page being rendered.
  */

--- a/crm/modules/email_list/email_list.inc.php
+++ b/crm/modules/email_list/email_list.inc.php
@@ -599,7 +599,6 @@ function email_list_options () {
         WHERE 1
         ORDER BY `list_name`, `lid` ASC
     ";
-    
     $res = mysqli_query($db_connect, $sql);
     if (!$res) crm_error(mysqli_error($res));
     // Store data
@@ -621,8 +620,15 @@ function email_list_options () {
  * @return an email subscribe form structure.
  */
 function email_list_subscribe_form ($cid) {
+    // Ensure user is allowed to edit lists
+    if (!user_access('email_list_subscribe')) {
+        error_register('User does not have permission: email_list_subscribe');
+        return null;
+    }
+    // Get contact data
     $contact_data = crm_get_data('contact', array('cid'=>$cid));
     $contact = $contact_data[0];
+    // Create form structure
     return array(
         'type' => 'form'
         , 'method' => 'post'
@@ -712,6 +718,12 @@ function email_list_unsubscribe_form ($subscription) {
  * @return an email list create form structure.
  */
 function email_list_create_form () {
+    // Ensure user is allowed to edit lists
+    if (!user_access('email_list_edit')) {
+        error_register('User does not have permission: email_list_edit');
+        return null;
+    }
+    // Create form structure
     $form = array(
         'type' => 'form'
         , 'method' => 'post'
@@ -844,6 +856,11 @@ function email_list_delete_form ($lid) {
  */
 function command_email_list_subscribe () {
     global $db_connect;
+    // Verify permissions
+    if (!user_access('email_list_subscribe')) {
+        error_register('Permission denied: email_list_subscribe');
+        return crm_url('contact&cid=' . $esc_post['cid']);
+    }
     $cid = $_POST['cid'];
     $email = $_POST['email'];
     $lid = $_POST['lid'];

--- a/crm/modules/email_list/email_list.inc.php
+++ b/crm/modules/email_list/email_list.inc.php
@@ -973,7 +973,7 @@ function email_list_page (&$page_data, $page_name, $options) {
             // Add email lists tab
             if ((user_access('contact_view') && $cid == user_id()) || user_access('contact_edit')) {
                 $email_lists = theme('table', crm_get_table('email_list_subscriptions', array('cid' => $cid)));
-                if ((user_access('contact_view') && $cid == user_id()) || user_access('contact_edit')) {
+                if ((user_access('email_list_subscribe') && $cid == user_id()) || user_access('email_list_edit_subscription')) {
                     $email_lists .= theme('form', crm_get_form('email_list_subscribe', $cid));
                 }
                 page_add_content_bottom($page_data, $email_lists, 'Emails');
@@ -983,7 +983,9 @@ function email_list_page (&$page_data, $page_name, $options) {
             page_set_title($page_data, 'Email Lists');
             if (user_access('email_list_view')) {
                 $email_lists = theme('table', 'email_list', array('join'=>array('contact', 'member'), 'show_export'=>false, 'lists_only'=>true));
-                $email_lists .= theme('form', crm_get_form('email_list_create'));
+                if (user_access('email_list_edit')) {
+                    $email_lists .= theme('form', crm_get_form('email_list_create'));
+                }
                 page_add_content_top($page_data, $email_lists, 'View');
             }
             break;
@@ -1008,7 +1010,7 @@ function email_list_page (&$page_data, $page_name, $options) {
             //Set page title
             page_set_title($page_data, email_list_description($lid));
             // Add edit tab
-            if (user_access('email_list_view') || user_access('email_list_edit')) {
+            if (user_access('email_list_edit')) {
                 page_add_content_top($page_data, theme('form', crm_get_form('email_list_edit', $lid), 'Edit'));
                 page_add_content_top($page_data, theme('table', 'email_list_subscribers', array('join'=>array('contact', 'member'), 'show_export'=>false, 'lists_only'=>false, 'lid'=>$lid)));
             }

--- a/crm/modules/member/command.inc.php
+++ b/crm/modules/member/command.inc.php
@@ -255,10 +255,6 @@ function command_member_plan_delete () {
 function command_member_membership_add () {
     global $esc_post;
     // Verify permissions
-    if (!user_access('member_edit')) {
-        error_register('Permission denied: member_edit');
-        return crm_url('members');
-    }
     if (!user_access('member_membership_edit')) {
         error_register('Permission denied: member_membership_edit');
         return crm_url('members');
@@ -283,10 +279,6 @@ function command_member_membership_add () {
 function command_member_membership_update () {
     global $esc_post;
     // Verify permissions
-    if (!user_access('member_edit')) {
-        error_register('Permission denied: member_edit');
-        return crm_url('members');
-    }
     if (!user_access('member_membership_edit')) {
         error_register('Permission denied: member_membership_edit');
         return crm_url('members');

--- a/crm/modules/member/command.inc.php
+++ b/crm/modules/member/command.inc.php
@@ -192,6 +192,11 @@ function command_member_edit () {
  */
 function command_member_plan_add () {
     global $esc_post;
+    // Verify permissions
+    if (!user_access('member_plan_edit')) {
+        error_register('Permission denied: member_plan_edit');
+        return crm_url('plans');
+    }
     $plan = array(
         'name' => $_POST['name']
         , 'price' => $_POST['price']
@@ -199,11 +204,6 @@ function command_member_plan_add () {
         , 'active' => $_POST['active'] ? '1' : '0'
         , 'pid' => $_POST['pid']
     );
-    // Verify permissions
-    if (!user_access('member_plan_edit')) {
-        error_register('Permission denied: member_plan_edit');
-        return crm_url('plans');
-    }
     // Add plan
     member_plan_save($plan);
     return crm_url('plans');
@@ -215,6 +215,11 @@ function command_member_plan_add () {
  */
 function command_member_plan_update () {
     global $esc_post;
+    // Verify permissions
+    if (!user_access('member_plan_edit')) {
+        error_register('Permission denied: member_plan_edit');
+        return crm_url('plans');
+    }
     $plan = array(
         'name' => $_POST['name']
         , 'price' => $_POST['price']
@@ -222,11 +227,6 @@ function command_member_plan_update () {
         , 'active' => $_POST['active'] ? '1' : '0'
         , 'pid' => $_POST['pid']
     );
-    // Verify permissions
-    if (!user_access('member_plan_edit')) {
-        error_register('Permission denied: member_plan_edit');
-        return crm_url('plans');
-    }
     // Update plan
     member_plan_save($plan);
     return crm_url('plans');

--- a/crm/modules/member/data.inc.php
+++ b/crm/modules/member/data.inc.php
@@ -227,7 +227,6 @@ function member_contact_api ($contact, $op) {
     switch ($op) {
         case 'create':
             // Add member
-            $member = $contact['member'];
             $sql = "
                 INSERT INTO `member`
                 (`cid`, `emergencyName`, `emergencyPhone`, `emergencyRelation`, `address1`, `address2`, `address3`, `town_city`, `zipcode`)
@@ -238,8 +237,8 @@ function member_contact_api ($contact, $op) {
             if (!$res) crm_error(mysqli_error($res));
             $contact['member']['cid'] = $contact['cid'];
             // Save memberships
-            if (isset($member['membership'])) {
-                foreach ($member['membership'] as $i => $membership) {
+            if (isset($contact['member']['membership'])) {
+                foreach ($contact['member']['membership'] as $i => $membership) {
                     $membership['cid'] = $contact['cid'];
                     $membership = member_membership_save($membership);
                     $contact['member']['membership'][$i] = $membership;

--- a/crm/modules/member/data.inc.php
+++ b/crm/modules/member/data.inc.php
@@ -95,8 +95,8 @@ function member_data ($opts = array()) {
     $row = mysqli_fetch_assoc($res);
     while (!empty($row)) {
         $member = array(
-            'cid' => $row['cid'],
-            'contact' => array(
+            'cid' => $row['cid']
+            , 'contact' => array(
                 'cid' => $row['cid']
                 , 'firstName' => $row['firstName']
                 , 'middleName' => $row['middleName']

--- a/crm/modules/member/page.inc.php
+++ b/crm/modules/member/page.inc.php
@@ -120,7 +120,7 @@ function member_page (&$page_data, $page_name, $options) {
                 $plan .= theme('form', crm_get_form('member_membership_add', $cid));
                 page_add_content_top($page_data, $plan, 'Plan');
             }
-            if (user_access('member_membership_edit')) {
+            if (user_access('user_role_edit')) {
                 $roles = theme('form', crm_get_form('user_role_edit', $cid));
                 page_add_content_top($page_data, $roles, 'Roles');
             }

--- a/crm/modules/member/table.inc.php
+++ b/crm/modules/member/table.inc.php
@@ -302,9 +302,12 @@ function member_membership_table ($opts = null) {
         }
         // Construct ops array
         $ops = array();
-        // Add delete op
+        // Add edit op
         if (user_access('member_membership_edit')) {
             $ops[] = '<a href=' . crm_url('membership&sid=' . $membership['sid'] . '&tab=edit') . '>edit</a>';
+        }
+        // Add delete op
+        if (user_access('member_edit')) {
             $ops[] = '<a href=' . crm_url('delete&type=member_membership&amp;id=' . $membership['sid']) . '>delete</a>';
         }
         // Add ops row

--- a/crm/modules/member/table.inc.php
+++ b/crm/modules/member/table.inc.php
@@ -130,7 +130,7 @@ function member_table ($opts = null) {
             $ops = array();
             // Add edit op
             if (user_access('member_edit')) {
-                $ops[] = '<a href=' . crm_url('contact&cid=' . $member['cid'] . '&tab=edit') .'>edit</a>';
+                $ops[] = '<a href=' . crm_url('contact&cid=' . $member['cid'] . '&tab=edit') . '>edit</a>';
             }
             // Add delete op
             if (user_access('member_delete')) {
@@ -391,7 +391,7 @@ function member_details_table ($opts = null) {
         $ops = array();
         // Add edit op
         if (user_access('member_edit')) {
-            $ops[] = '<a href='. crm_url('contact&cid=' . $member['cid'] . '&tab=edit') . '>edit</a> ';
+            $ops[] = '<a href=' . crm_url('contact&cid=' . $member['cid'] . '&tab=edit') . '>edit</a>';
         }
         // Add ops row
         if (!$export && (user_access('member_edit'))) {

--- a/crm/modules/mentor/mentor.inc.php
+++ b/crm/modules/mentor/mentor.inc.php
@@ -646,9 +646,11 @@ function mentor_page (&$page_data, $page_name, $options) {
                 return;
             }
             // Add mentors tab
-            if (user_access('mentor_view') || user_access('mentor_edit') || user_access('mentor_delete') || $cid == user_id()) {
+            if (user_access('mentor_view') || $cid == user_id()) {
                 $mentorships = theme('table', crm_get_table('mentor', array('cid' => $cid)));
-                $mentorships .= theme('form', crm_get_form('mentor_add', $cid));
+                if (user_access('mentor_edit')) {
+                    $mentorships .= theme('form', crm_get_form('mentor_add', $cid));
+                }
                 page_add_content_bottom($page_data, $mentorships, 'Mentor');
             }
             break;

--- a/crm/modules/mentor/mentor.inc.php
+++ b/crm/modules/mentor/mentor.inc.php
@@ -547,7 +547,7 @@ function command_mentor_add() {
     // Verify permissions
     if (!user_access('mentor_edit')) {
         error_register('Permission denied: mentor_edit');
-        return crm_url('');
+        return crm_url('contact&cid=' . $_POST['cid']);
     }
     // Query database
     $sql = "
@@ -593,7 +593,7 @@ function command_mentor_update() {
     ";
     $res = mysqli_query($db_connect, $sql);
     if (!$res) crm_error(mysqli_error($res));
-    return crm_url('contact&cid=' . $esc_post['cid'] . '#tab-mentor');
+    return crm_url('contact&cid=' . $_POST['cid'] . '#tab-mentor');
 }
 
 /**
@@ -606,7 +606,7 @@ function command_mentor_delete() {
     // Verify permissions
     if (!user_access('mentor_delete')) {
         error_register('Permission denied: mentor_delete');
-        return crm_url('');
+        return crm_url('contact&cid=' . $_POST['cid']);
     }
     // Query database
     $sql = "
@@ -615,7 +615,7 @@ function command_mentor_delete() {
     ";
     $res = mysqli_query($db_connect, $sql);
     if (!$res) crm_error(mysqli_error($res));
-    return crm_url('members');
+    return crm_url('contact&cid=' . $_POST['cid']);
 }
 
 // Pages ///////////////////////////////////////////////////////////////////////

--- a/crm/modules/mentor/mentor.inc.php
+++ b/crm/modules/mentor/mentor.inc.php
@@ -71,15 +71,25 @@ function mentor_install($old_revision = 0) {
             , '8' => 'webAdmin'
         );
         //Set director (rid 3) as the default role that can administer mentors.
-        $sql = "
-            INSERT INTO `role_permission` (`rid`, `permission`)
-            VALUES
-            ('3', 'mentor_view'),
-            ('3', 'mentor_edit'),
-            ('3', 'mentor_delete')
-        ";
-        $res = mysqli_query($db_connect, $sql);
-        if (!$res) crm_error(mysqli_error($res));
+        $default_perms = array(
+            'director' => array('mentor_view', 'mentor_edit', 'mentor_delete')
+        );
+        foreach ($roles as $rid => $role) {
+            $esc_rid = mysqli_real_escape_string($db_connect, $rid);
+            if (array_key_exists($role, $default_perms)) {
+                foreach ($default_perms[$role] as $perm) {
+                    $esc_perm = mysqli_real_escape_string($db_connect, $perm);
+                    $sql = "
+                        INSERT INTO `role_permission`
+                        (`rid`, `permission`)
+                        VALUES
+                        ('$esc_rid', '$esc_perm')
+                    ";
+                    $res = mysqli_query($db_connect, $sql);
+                    if (!$res) crm_error(mysqli_error($res));
+                }
+            }
+        }
     }
     if ($old_revision < 2) {
         $roles = array(

--- a/crm/modules/mentor/mentor.inc.php
+++ b/crm/modules/mentor/mentor.inc.php
@@ -370,6 +370,7 @@ function mentor_table ($opts) {
 function mentor_add_form ($cid) {
     // Ensure user is allowed to edit mentors
     if (!user_access('mentor_edit')) {
+        error_register('User does not have permission: mentor_edit');
         return null;
     }
     // Create form structure
@@ -411,6 +412,7 @@ function mentor_add_form ($cid) {
 function mentor_edit_form ($cid) {
     // Ensure user is allowed to edit mentor
     if (!user_access('mentor_edit')) {
+        error_register('User does not have permission: mentor_edit');
         return null;
     }
     // Get corresponding contact data
@@ -477,6 +479,7 @@ function mentor_edit_form ($cid) {
 function mentor_delete_form ($cid) {
     // Ensure user is allowed to delete mentors
     if (!user_access('mentor_delete')) {
+        error_register('User does not have permission: mentor_delete');
         return null;
     }
     // Get corresponding contact data

--- a/crm/modules/mentor/mentor.inc.php
+++ b/crm/modules/mentor/mentor.inc.php
@@ -308,10 +308,6 @@ function mentor_table ($opts) {
                 if (!$export && (user_access('mentor_edit') || user_access('mentor_delete'))) {
                     // Construct ops array
                     $ops = array();
-                    // Add edit op
-                    //if (user_access('mentor_edit')) {
-                    //    $ops[] = '<a href=' . crm_url('contact&cid=' . $mentor['cid'] . '#tab-mentor') . '>edit</a> ';
-                    //}
                     // Add delete op
                     if (user_access('mentor_delete')) {
                         $ops[] = '<a href=' . crm_url('delete&type=mentor&id=' . $contact['cid'] . '&mentorcid=' . $mentor['cid']) . '>delete</a>';
@@ -342,10 +338,6 @@ function mentor_table ($opts) {
                 if (!$export && (user_access('mentor_edit') || user_access('mentor_delete'))) {
                     // Construct ops array
                     $ops = array();
-                    // Add edit op
-                    //if (user_access('mentor_edit')) {
-                    //    $ops[] = '<a href=' . crm_url('contact&cid=' . $contact['cid'] . '#tab-mentor') . '>edit</a>';
-                    //}
                     // Add delete op
                     if (user_access('mentor_delete')) {
                         $ops[] = '<a href=' . crm_url('delete&type=mentor&id=' . $protege['cid'] . '&mentorcid=' . $contact['cid']) . '>delete</a>';
@@ -396,73 +388,6 @@ function mentor_add_form ($cid) {
                     , array(
                         'type' => 'submit'
                         , 'value' => 'Add'
-                    )
-                )
-            )
-        )
-    );
-    return $form;
-}
-
-/**
- * Return the form structure for an edit mentor assignment form.
- * @param $cid The cid of the protege to edit.
- * @return The form structure.
- */
-function mentor_edit_form ($cid) {
-    // Ensure user is allowed to edit mentor
-    if (!user_access('mentor_edit')) {
-        error_register('User does not have permission: mentor_edit');
-        return null;
-    }
-    // Get corresponding contact data
-    $data = crm_get_data ('contact', $opts = array('cid' => $cid));
-    $contact = $data[0];
-    // Construct member name
-    $name = member_name($contact['firstName'], $contact['middleName'], $contact['lastName']);
-    // Get list of current mentor cids.
-    $mentor_cids = $contact['member']['mentorships']['mentor_cids'];
-    // Construct mentor name (from member/protege)
-    $mentor_name = crm_get_data('contact', $opts = array('cid' => $mentor_cids[0]));
-    // Get list of current protege cids.
-    $protege_cids = $contact['member']['mentorships']['protege_cids'];
-    // Construct protege name (from member/protege) TODO: Change this to an array of protege's
-    $protege_name = crm_get_data('contact', $opts = array('cid' => $protege_cids[0]));
-    // Create form structure
-    $form = array(
-        'type' => 'form'
-        , 'method' => 'post'
-        , 'command' => 'mentor_update'
-        , 'hidden' => array(
-            'cid' => $cid
-        )
-        , 'fields' => array(
-            array(
-                'type' => 'fieldset'
-                , 'label' => 'Edit Mentor Info'
-                , 'fields' => array(
-                    array(
-                        'type' => 'readonly'
-                        , 'label' => 'Name'
-                        , 'value' => $name
-                    )
-                    , array(
-                        'type' => 'text'
-                        , 'class' => 'date'
-                        , 'label' => 'Mentor'
-                        , 'name' => 'mentor'
-                        , 'value' => $mentor_name
-                    )
-                    , array(
-                        'type' => 'text'
-                        , 'class' => 'date'
-                        , 'label' => 'Protege'
-                        , 'name' => 'protege'
-                        , 'value' => $protege_name
-                    )
-                    , array(
-                        'type' => 'submit'
-                        , 'value' => 'Update'
                     )
                 )
             )
@@ -555,41 +480,6 @@ function command_mentor_add() {
         (`cid`, `mentor_cid`)
         VALUES
         ('$esc_post[cid]', '$esc_post[mentor_cid]')
-    ";
-    $res = mysqli_query($db_connect, $sql);
-    if (!$res) crm_error(mysqli_error($res));
-    return crm_url('contact&cid=' . $_POST['cid'] . '#tab-mentor');
-}
-
-/**
- * Handle mentor update request.
- * @return The url to display on completion. TODO: This function is not completely
- * implemented yet, it still has some copied parts from the key module that have
- * not been translated
- */
-function command_mentor_update() {
-    global $db_connect;
-    global $esc_post;
-    // Verify permissions
-    if (!user_access('mentor_edit')) {
-        error_register('Permission denied: mentor_edit');
-        return crm_url('contact&cid=' . $_POST['cid']);
-    }
-    // Query database
-    $sql = "
-        UPDATE `mentor`
-        SET
-        `start`='$esc_post[start]',
-    ";
-    if (!empty($esc_post['end'])) {
-        $sql .= "`end`='$esc_post[end]',";
-    } else {
-        $sql .= "`end`=NULL,";
-    }
-    $sql .= "
-        `serial`='$esc_post[serial]',
-        `slot`='$esc_post[slot]'
-        WHERE `kid`='$esc_post[kid]'
     ";
     $res = mysqli_query($db_connect, $sql);
     if (!$res) crm_error(mysqli_error($res));


### PR DESCRIPTION
There are 2 significant changes here:

- To display the "user role edit" tab & form, on the member page, the logged in user must now have the "user_role_edit" permission instead of "member_membership_edit", which makes more sense as it now matches the required permission for the command.
- I've also split out the edit & delete ops for subscriptions, the delete op now requires the member_edit permission; this means that if spaces wish to allow the users to self-manage their subscription, this can now be done by allowing members to have the "member_membership_edit" permission to add & edit subscriptions, but prevents them from removing a subscripton completely