### PR TITLE
Fix plan user plan edit and paypal email delete

### DIFF
--- a/crm/modules/member/form.inc.php
+++ b/crm/modules/member/form.inc.php
@@ -432,7 +432,7 @@ function member_membership_edit_form ($sid) {
         return array();
     }
     // Construct contact name
-    $data = member_contact_data(array('cid'=>$membership['cid']));
+    $data = member_data(array('cid'=>$membership['cid']));
     $contact = $data[0];
     $name = theme_contact_name($contact['cid']);
     // Create form structure

--- a/crm/modules/member/utility.inc.php
+++ b/crm/modules/member/utility.inc.php
@@ -30,7 +30,7 @@ function member_membership_description ($sid) {
     $data = member_membership_data(array('sid'=>$sid));
     $membership = $data[0];
     // Get member contact info
-    $data = member_contact_data(array('cid'=>$membership['cid']));
+    $data = member_data(array('cid'=>$membership['cid']));
     $contact = $data[0];
     // Construct description
     $description = 'Membership: ';

--- a/crm/modules/paypal_payment/paypal_payment.inc.php
+++ b/crm/modules/paypal_payment/paypal_payment.inc.php
@@ -161,9 +161,12 @@ function paypal_payment_contact_data ($opts = array()) {
             if ($filter === 'email') {
                 $esc_email = mysqli_real_escape_string($db_connect, $value);
                 $sql .= "
-                    AND `email`='$esc_email'
+                AND `email`='$esc_email'
                 ";
             }
+            $sql .= "
+                AND $filter='$value'
+                ";
         }
     }
     $res = mysqli_query($db_connect, $sql);
@@ -496,7 +499,7 @@ function paypal_payment_contact_delete_form ($cid) {
         return crm_url('paypal-admin');
     }
     // Get paypal contact data
-    $data = crm_get_data('paypal_payment_contact', array('cid'=>$cid));
+    $data = crm_get_data('paypal_payment_contact', array('filter'=>array('cid'=>$cid)));
     $paypal_payment_contact = $data[0];
     // Construct paypal contact name
     $paypal_payment_contact_name = "paypal contact:$paypal_payment_contact[cid] email:$paypal_payment_contact[email]";


### PR DESCRIPTION
On user plan edit a call to non existent function member_contact_data causes error 500

On paypal email delete call, the cid is not passed as filter, as a result, the first db entry is returned