### PR TITLE
change reference from members to contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Seltzer CRM 0.7.32 - An open source CRM for hackerspaces  
+Seltzer CRM 0.7.33 - An open source CRM for hackerspaces  
 Copyright 2009-2023 Edward L. Platt <ed@elplatt.com>  
 Distributed under GPLv3 (see COPYING for more info)
 

--- a/crm/include/crm.inc.php
+++ b/crm/include/crm.inc.php
@@ -24,7 +24,7 @@
 $crm_version = array(
     'major' => 0
     , 'minor' => 7
-    , 'patch' => 32
+    , 'patch' => 33
     , 'revision' => 'dev'
 );
 require_once($crm_root . '/config.inc.php');

--- a/crm/modules/contact/contact.inc.php
+++ b/crm/modules/contact/contact.inc.php
@@ -512,7 +512,7 @@ function command_contact_add () {
     // Check permissions
     if (!user_access('contact_add')) {
         error_register('Permission denied: contact_add');
-        return crm_url('members');
+        return crm_url('contacts');
     }
     // Build contact object
     $contact = array(
@@ -537,13 +537,13 @@ function command_contact_update () {
     // Verify permissions
     if (!user_access('contact_edit') && $_POST['cid'] != user_id()) {
         error_register('Permission denied: contact_edit');
-        return crm_url('members');
+        return crm_url('contacts');
     }
     $contact_data = crm_get_data('contact', array('cid'=>$_POST['cid']));
     $contact = $contact_data[0];
     if (empty($contact)) {
         error_register("No contact for cid: ${_POST['cid']}");
-        return crm_url('members');
+        return crm_url('contacts');
     }
     // Update contact data
     $contact['firstName'] = $_POST['firstName'];
@@ -553,7 +553,7 @@ function command_contact_update () {
     $contact['phone'] = $_POST['phone'];
     // Save changes to database
     $contact = contact_save($contact);
-    return crm_url('members');
+    return crm_url('contacts');
 }
 
 /**
@@ -564,10 +564,10 @@ function command_contact_delete () {
     // Verify permissions
     if (!user_access('contact_delete')) {
         error_register('Permission denied: contact_delete');
-        return crm_url('members');
+        return crm_url('contacts');
     }
     contact_delete($_POST['cid']);
-    return crm_url('members');
+    return crm_url('contacts');
 }
 
 // Pages ///////////////////////////////////////////////////////////////////////

--- a/crm/modules/user/user.inc.php
+++ b/crm/modules/user/user.inc.php
@@ -1023,12 +1023,12 @@ function command_user_role_update () {
     // Check permissions
     if (!user_access('user_edit')) {
         error_register('Current user does not have permission: user_edit');
-        return crm_url('members');
+        return crm_url('contacts');
     }
     // Check permissions
     if (!user_access('user_role_edit')) {
         error_register('Current user does not have permission: user_role_edit');
-        return crm_url('members');
+        return crm_url('contacts');
     }
     $roles = user_role_data();
     // Delete all roles for specified user


### PR DESCRIPTION
repoint URL references for members to contacts - it's possible to have the member module disabled, but these links create a dependency on a module that's loaded after the contact & user modules